### PR TITLE
Just some simple cleanup

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,9 +1,13 @@
-const express = require('express');
+import express from 'express';
+import { join } from 'path';
 
-const server = express();
-server.use(express.static(`${__dirname}/build`));
+const app = express();
+app.use(express.static(join(__dirname, 'build')));
+app.get('/*', (req, res) => {
+  res.sendFilePath(join(__dirname, 'build', 'index.html'));
+});
 
 const port = 8080;
-server.listen(port, () => {
+app.listen(port, () => {
   console.log(`server listening on port ${port}`);
 });

--- a/src/components/map/flightMap.js
+++ b/src/components/map/flightMap.js
@@ -238,7 +238,19 @@ class FlightMap extends Component {
         zoom,
       };
       drawLie(drawLieOptions);
-      lieLabels.push([lie, `${disc.company} ${disc.name}`]);
+      let discName;
+      if (disc.displayName) {
+        if (disc.weight) {
+          discName = `${disc.displayName} - ${disc.weight}g`;
+        } else {
+          discName = disc.displayName;
+        }
+      } else if (disc.weight) {
+        discName = `${disc.company} ${disc.name} - ${disc.weight}g`;
+      } else {
+        discName = `${disc.company} ${disc.name}`;
+      }
+      lieLabels.push([lie, discName]);
     });
 
     const context = canvas.getContext('2d');

--- a/src/components/modals/editDiscModal.js
+++ b/src/components/modals/editDiscModal.js
@@ -84,13 +84,14 @@ const EditDiscModal = (props) => {
     if (maxWeight) {
       return (
         <div className="editBlock">
-          <label htmlFor="discWeight">Weight (optional): {weight || maxWeight}</label>
+          <label htmlFor="discWeight">Weight (optional): {weight || maxWeight}g</label>
           <Slider
             value={weight || maxWeight}
             orientation="horizontal"
             min={120}
             max={maxWeight}
             className="wear-slider"
+            format={(value) => `${value}g`}
             onChange={handleDiscWeightChange}
           />
         </div>
@@ -111,7 +112,7 @@ const EditDiscModal = (props) => {
         { (!hideWeight) ? displayWeightSelector(weight, maxWeight) : null}
         { (!hidePower) ? (
           <div className="editBlock">
-            <label htmlFor="discPower">Power (optional): {powerPercentage(power || throwerPower)}</label>
+            <label htmlFor="discPower">Power (optional, % of nominal airspeed required): {powerPercentage(power || throwerPower)}</label>
             <Slider
               value={power || throwerPower}
               orientation="horizontal"
@@ -124,7 +125,7 @@ const EditDiscModal = (props) => {
           </div>) : null }
         { (!hideThrowType) ? (
           <div className="editBlock" >
-            <label htmlFor="discThrowType">ThrowType (optional): </label>
+            <label htmlFor="discThrowType">Throw Type (optional): </label>
             <Select
               name="ThrowerTypeSelector"
               id="ThrowerTypeSelector"
@@ -136,7 +137,7 @@ const EditDiscModal = (props) => {
           </div>) : null }
         { (!hideWear) ? (
           <div className="editBlock">
-            <label htmlFor="discWear">Wear (optional): {wear}</label>
+            <label htmlFor="discWear">Wear (optional, using the sleepy scale): {wear}/10</label>
             <Slider
               value={wear}
               orientation="horizontal"


### PR DESCRIPTION
* Updated the Display name of a disc to include the set weight if there is one, and to use the DisplayName if it is set (so you can tell exactly which disc is that moonglow, beat-in opto air explorer_.
* Updated terminology on the Edit modal to hopefully clarify some things like 'Power' and 'Wear'
* Updated the server settings to hopefully fix the error with hitting `CTRL + F5` when in production.